### PR TITLE
Handle NODATA response status gracefully

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resolve-hosts"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     { name="Darren Spruell", email="dspruell@sancho2k.net" },
 ]

--- a/resolve_hosts.py
+++ b/resolve_hosts.py
@@ -1,12 +1,12 @@
 """Resolve list of DNS hostnames."""
 
 import argparse
-from importlib.metadata import version
-from ipaddress import ip_address
 import logging
 import sys
+from importlib.metadata import version
+from ipaddress import ip_address
 
-from dns.resolver import Resolver, resolve, NXDOMAIN
+from dns.resolver import NXDOMAIN, NoAnswer, Resolver, resolve
 from tabulate import tabulate
 
 try:
@@ -111,6 +111,8 @@ def cli():
             answer = resolver.resolve(fqdn)
         except NXDOMAIN:
             answer = ["NXDOMAIN"]
+        except NoAnswer:
+            answer = ["NODATA (no answer)"]
         if args.json:
             resp_data.append({fqdn: [str(addr) for addr in answer]})
         else:


### PR DESCRIPTION
Handle "NODATA" response status scenario to avoid raising an exception. This exception occurred in cases where a NOERROR response code was returned containing zero answers.

Fix #1.