### PR TITLE
Handle NoNameservers in name list resolutions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resolve-hosts"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     { name="Darren Spruell", email="phatbuckett@gmail.com" },
 ]

--- a/resolve_hosts/cli.py
+++ b/resolve_hosts/cli.py
@@ -97,6 +97,8 @@ def resolve_hosts():
             answer = ["NXDOMAIN"]
         except NoAnswer:
             answer = ["NODATA (no answer)"]
+        except NoNameservers:
+            answer = ["nameservers failed (no answer)"]
         if args.json:
             resp_data.append({fqdn: [str(addr) for addr in answer]})
         else:


### PR DESCRIPTION
Handle NoNameservers exception, raised in cases like REFUSED and SERVFAIL.

Fixes #9.